### PR TITLE
fix: add lodash as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "cdk-datadog",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk-datadog",
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "dependencies": {
+        "lodash": "4.17.21"
+      },
       "devDependencies": {
         "@aws-cdk/assert": "^2.12.0",
         "@types/jest": "26.0.20",
@@ -4007,8 +4010,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com:443/npm/avrios-npm/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -9550,8 +9552,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com:443/npm/avrios-npm/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.truncate": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-datadog",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
@@ -20,5 +20,8 @@
   "peerDependencies": {
     "aws-cdk-lib": "^2.8.0",
     "constructs": "^10.0.0"
+  },
+  "dependencies": {
+    "lodash": "4.17.21"
   }
 }


### PR DESCRIPTION
This prevents downstream consumers needing to include it in their
own `package.json`