### PR TITLE
feat: support on-missing-data option

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -55,6 +55,17 @@ export interface DatadogMonitorOptions {
      * The threshold definitions
      */
     readonly thresholds?: DatadogMonitorThresholds;
+
+    /**
+     * Controls how groups or monitors are treated if an evaluation does not return any data points.
+     * 
+     * The default option results in different behavior depending on the monitor query type.
+     * For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+     * For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+     * 
+     * This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+     */
+    readonly onMissingData?: 'default' | 'show_no_data' | 'show_and_notify_no_data' | 'resolve';
 }
 
 export interface DatadogMonitorThresholds {
@@ -107,7 +118,8 @@ export class DatadogMonitor extends Construct {
                             CriticalRecovery: props.options?.thresholds?.criticalRecovery,
                             Warning: props.options?.thresholds?.warning,
                             WarningRecovery: props.options?.thresholds?.warningRecovery,
-                        }
+                        },
+                        OnMissingData: props.options?.onMissingData,
                     } : undefined
                 },
                 props.additionalMonitorParams

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdk-datadog",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk-datadog",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "lodash": "4.17.21"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-datadog",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Adds support for:
![Screenshot 2025-04-28 at 11 47 16 AM](https://github.com/user-attachments/assets/8537c742-bb28-40b0-82dd-72db0bf31a7b)
